### PR TITLE
작품 둘러보기 페이지 필터 사이드바를 우측으로 이동

### DIFF
--- a/app/explore/explore-client.tsx
+++ b/app/explore/explore-client.tsx
@@ -46,15 +46,8 @@ export function ExploreClient({
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-        {/* Filter Sidebar */}
-        <aside className="md:col-span-1">
-          <div className="sticky top-4">
-            <FilterSidebar categories={categories} artists={artists} />
-          </div>
-        </aside>
-
         {/* Artworks Grid */}
-        <main className="md:col-span-3">
+        <main className="md:col-span-3 order-last md:order-none">
           {artworks.length > 0 ? (
             <>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -95,6 +88,13 @@ export function ExploreClient({
             </div>
           )}
         </main>
+
+        {/* Filter Sidebar */}
+        <aside className="md:col-span-1 order-first md:order-none">
+          <div className="sticky top-4">
+            <FilterSidebar categories={categories} artists={artists} />
+          </div>
+        </aside>
       </div>
     </div>
   );


### PR DESCRIPTION
## 📋 변경 사항

작품 둘러보기 페이지(`/explore`)에서 필터 사이드바를 왼쪽에서 오른쪽으로 이동하여 레이아웃을 개선했습니다.

### 주요 변경 내용

- **데스크톱**: 작품 그리드(왼쪽) + 필터 사이드바(오른쪽) 레이아웃
- **모바일**: 필터(위) + 작품(아래) - 기존 UX 유지
- **접근성**: HTML 순서 변경으로 스크린 리더 사용자가 콘텐츠를 먼저 접근

### 구현 방법

CSS Grid의 `order` 속성을 활용하여 반응형 레이아웃을 구현했습니다:

```tsx
<main className="md:col-span-3 order-last md:order-none">
  {/* 작품 그리드 */}
</main>

<aside className="md:col-span-1 order-first md:order-none">
  {/* 필터 사이드바 */}
</aside>
```

- **모바일** (`grid-cols-1`): `order-first` (필터) → `order-last` (작품)
- **데스크톱** (`md:grid-cols-4`): `md:order-none` (HTML 순서대로)

## 🧪 테스트 계획

- [x] 데스크톱 뷰에서 필터가 우측에 표시
- [x] 모바일 뷰에서 필터가 위, 작품이 아래 표시
- [x] Sticky 동작 정상 작동
- [x] 반응형 레이아웃 정상 작동

## 📝 변경된 파일

- `app/explore/explore-client.tsx`: 레이아웃 순서 변경 및 order 클래스 추가

## ✅ 체크리스트

- [x] 코드 수정 완료
- [x] 데스크톱 뷰 테스트 완료
- [x] 모바일 뷰 테스트 완료
- [x] 접근성 개선 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)